### PR TITLE
Improve name convention and resolution.

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -39,7 +39,7 @@ group 'devpi administrative group' do
   members node[:devpiserver][:daemon_user]
 end
 
-python_pip 'devpi server' do
+python_pip 'devpi-server' do
   package_name 'devpi-server'
   action :upgrade
   virtualenv '/opt/devpi-server'


### PR DESCRIPTION
Hi - My installs fail when run in kitchen. In spite of the package_name setting, the method name is taken and pip fails to install devpi-server because it can't find it. I thought the dash would be good for intuitive naming besides.
