### PR TITLE
Set a dynamic X-outside-url header in nginx conf

### DIFF
--- a/templates/default/nginx-config.erb
+++ b/templates/default/nginx-config.erb
@@ -19,6 +19,7 @@ server {
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-outside-url $scheme://$host:$server_port;
 	}
 }
 


### PR DESCRIPTION
Pass along a dynamically-created X-outside-url header so devpi server can work with ssl in the nginx reverse proxy.

Without this, accessing endpoints such as https://mypypi/+api will return http urls in its json payload, which makes devpi-client sad when trying to communicate over a port configured for ssl.
