### PR TITLE
Add support for devpi replicas

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,3 +23,7 @@ suites:
 - name: lwrp
   run_list:
   - "recipe[lwrp-test]"
+- name: replica
+  run_list:
+  - "recipe[replica-test::master]"
+  - "recipe[replica-test::replica]"

--- a/Berksfile
+++ b/Berksfile
@@ -9,4 +9,5 @@ group :testing do
   cookbook 'supervisor'
   cookbook 'lwrp-test', path: 'test/cookbooks/lwrp-test'
   cookbook 'supervisor-daemon', path: 'test/cookbooks/supervisor-daemon'
+  cookbook 'replica-test', path: 'test/cookbooks/replica-test'
 end

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -6,6 +6,8 @@ DEPENDENCIES
   lwrp-test
     path: test/cookbooks/lwrp-test
   nginx
+  replica-test
+    path: test/cookbooks/replica-test
   supervisor
   supervisor-daemon
     path: test/cookbooks/supervisor-daemon
@@ -15,7 +17,7 @@ GRAPH
   bluepill (2.3.1)
     rsyslog (>= 0.0.0)
   build-essential (2.1.3)
-  devpi (2.0.0)
+  devpi (2.1.0)
     nginx (>= 0.0.0)
     python (>= 0.0.0)
   lwrp-test (0.1.0)
@@ -31,6 +33,9 @@ GRAPH
   python (1.4.6)
     build-essential (>= 0.0.0)
     yum-epel (>= 0.0.0)
+  replica-test (0.1.0)
+    devpi (>= 0.0.0)
+    supervisor (>= 0.0.0)
   rsyslog (1.12.2)
   runit (1.5.10)
     build-essential (>= 0.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is used to list changes made in each version of the devpi cookbook.
   in `Chef::DSL::IncludeRecipe`.  I'm not completely sure why... Pushing
   the `include_recipe` into the user works reliably.
 - Rewrite server recipe to use the `devpi_server` LWRP.
+- Add `replicate` option to the `devpi_server` LWRP.
 
 ## 2.0.0
 - Fully embrace ChefDK for development.

--- a/FEATURES.org
+++ b/FEATURES.org
@@ -37,7 +37,8 @@ this file is -- /a list of things that need do'ing/.
   [X] Remove git-flow nonsense
   [X] Add nginx configuration LWRP
 
-* Version 2.1 [0/3]
-  [ ] Add `devpi_slave` LWRP
+* Version 2.1 [1/4]
+  [X] Add `replicate` option to devpi_server LWRP
+  [ ] Add `devpi_service` LWRP
   [ ] Add `devpi_user` LWRP
   [ ] Add `devpi_index` LWRP

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ create a workstation from which you can manage a devpi-server installation.
 
 [nginx]: http://nginx.org/
 
-### devpi_server
+### devpi\_server
 This resource defines a complete installation of the [devpi server].  It will
 create the Python virtual environment, install the packages/users/groups
 needed to run the server, and even generate an nginx site definition for you.
@@ -170,9 +170,16 @@ using the normal syntax:
       package will be installed.  If this is omitted or set to
       <tt>nil</tt>, then the most recent package will be installed.</td>
   </tr>
+  <tr>
+    <td><tt>replicate</tt></td>
+    <td>If this attribute is set, then the server will be installed
+      as a replica of the specified master URL.  If this is omitted or
+      set to <tt>nil</tt>, then the server will be installed as a
+      master.</td>
+  </tr>
 </table>
 
-### devpi\_nginx_site
+### devpi\_nginx\_site
 This resource uses the `devpi-server` command to generate an nginx site for
 the server and optionally enable it.
 
@@ -265,7 +272,7 @@ the server and make it available at <http://172.16.0.11/>.
 
 ### License:
 
-Copyright (C) 2013-2014 Dave Shawley
+Copyright (C) 2013-2015 Dave Shawley
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/files/default/bootstrap-devpi
+++ b/files/default/bootstrap-devpi
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# bootstrap-devpi - Bootstrap the devpi-server instance.
+#
+
+server_root=$1
+shift
+if test -z "$1"
+then
+  echo "Usage: $0 SERVER-ROOT ARGS"
+  exit 64
+fi
+
+clean_exit() {
+  pid=`ps -e -opid,command | grep [d]evpi-server | awk '{print $1}'`
+  if test -n "$pid"
+  then
+    kill -INT $pid
+  fi
+}
+
+(sleep 10 && echo "TIMEOUT" && clean_exit) &
+alarm_pid=$!
+
+set -e
+$server_root/bin/devpi-server "$@" 2>&1 | while
+  read line
+do
+  if echo $line | grep -qi 'hit ctrl-c to quit' -
+  then
+    pid=`ps -e -opid,command | grep [d]evpi-server | awk '{print $1}'`
+    kill -KILL $alarm_pid
+    clean_exit
+  fi
+done

--- a/providers/server.rb
+++ b/providers/server.rb
@@ -75,7 +75,12 @@ action :create do
 
   command_root = %W(
     #{root_directory}/bin/devpi-server --serverdir "#{data_directory}"
-  ).join(' ')
+  )
+  if new_resource.replicate
+    command_root << ['--role', 'replica', '--master', new_resource.replicate]
+  end
+
+  command_root = command_root.flatten.join(' ')
   unless ::File.exist?(::File.join([data_directory, '.event_serial']))
     execute 'start devpi-server' do
       cwd root_directory

--- a/providers/server.rb
+++ b/providers/server.rb
@@ -73,23 +73,20 @@ action :create do
     recursive true
   end
 
-  command_root = %W(
-    #{root_directory}/bin/devpi-server --serverdir "#{data_directory}"
-  )
-  if new_resource.replicate
-    command_root << ['--role', 'replica', '--master', new_resource.replicate]
+  cookbook_file 'bootstrap-devpi' do
+    path '/tmp/bootstrap-devpi'
+    cookbook 'devpi'
+    mode 00755
   end
 
-  command_root = command_root.flatten.join(' ')
   unless ::File.exist?(::File.join([data_directory, '.event_serial']))
-    execute 'start devpi-server' do
-      cwd root_directory
-      command "#{command_root} --port #{port} --start"
-      user daemon_user
+    args = %W(--serverdir #{data_directory} --port #{port})
+    if new_resource.replicate
+      args << ['--role', 'replica', '--master', new_resource.replicate]
     end
-    execute 'stop devpi-server' do
+    execute "Bootstrap #{root_directory}" do
       cwd root_directory
-      command "#{command_root} --stop"
+      command "/tmp/bootstrap-devpi #{args.flatten}"
       user daemon_user
     end
   end

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -27,5 +27,6 @@ attribute :port, kind_of: Integer, default: 3141
 attribute :data_directory, kind_of: String
 attribute :nginx_site, kind_of: [String, NilClass], default: nil
 attribute :version, kind_of: [String, NilClass], default: nil
+attribute :replicate, kind_of: [String, NilClass], default: nil
 
 state_attrs :version, :directory

--- a/test/cookbooks/replica-test/metadata.rb
+++ b/test/cookbooks/replica-test/metadata.rb
@@ -1,0 +1,9 @@
+name 'replica-test'
+maintainer 'Dave Shawley'
+maintainer_email 'daveshawley@gmail.com'
+license 'Apache 2.0'
+description 'Used to test the devpi replication.'
+version '0.1.0'
+
+depends 'devpi'
+depends 'supervisor'

--- a/test/cookbooks/replica-test/recipes/master.rb
+++ b/test/cookbooks/replica-test/recipes/master.rb
@@ -1,0 +1,31 @@
+#
+# Cookbook Name:: replica-test
+# Recipe:: master
+#
+# Copyright 2015, Dave Shawley
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include_recipe 'python'
+include_recipe 'supervisor'
+
+devpi_server '/opt/devpi/master' do
+  port 3142
+end
+
+supervisor_service 'devpi-master' do
+  command '/opt/devpi/master/bin/devpi-server --port 3142 --role master --serverdir /opt/devpi/master/data'
+  user 'devpi'
+  action :enable
+  autostart true
+end

--- a/test/cookbooks/replica-test/recipes/replica.rb
+++ b/test/cookbooks/replica-test/recipes/replica.rb
@@ -1,0 +1,31 @@
+#
+# Cookbook Name:: replica-test
+# Recipe:: replica
+#
+# Copyright 2015, Dave Shawley
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include_recipe 'python'
+include_recipe 'supervisor'
+
+devpi_server '/opt/devpi/slave' do
+  port 3143
+end
+
+supervisor_service 'devpi-replica' do
+  command '/opt/devpi/slave/bin/devpi-server --port 3143 --role replica --master-url http://localhost:3142 --serverdir /opt/devpi/slave/data'
+  user 'devpi'
+  action :enable
+  autostart true
+end

--- a/test/cookbooks/replica-test/recipes/replica.rb
+++ b/test/cookbooks/replica-test/recipes/replica.rb
@@ -21,6 +21,7 @@ include_recipe 'supervisor'
 
 devpi_server '/opt/devpi/slave' do
   port 3143
+  replicate 'http://localhost:3142'
 end
 
 supervisor_service 'devpi-replica' do

--- a/test/integration/replica/bats/connection_tests.bats
+++ b/test/integration/replica/bats/connection_tests.bats
@@ -1,0 +1,18 @@
+load test_helpers
+
+@test "master is listening on configured port" {
+	http_get 'http://localhost:3142/+status' | grep role | grep MASTER
+}
+
+@test "replica is listening on configured port" {
+	http_get 'http://localhost:3143/+status' | grep role | grep REPLICA
+}
+
+@test "replica is connected to master" {
+	master_url=`http_get 'http://localhost:3143/+status' | sed -ne '/master-url/s/^.*: "\([^"]*\)".*$/\1/p'`
+	test "$master_url" = "http://localhost:3142"
+}
+
+@test "master is connected to replica" {
+	http_get 'http://localhost:3142/+status' | grep -A10 polling_replicas | grep 'remote-ip.*127.0.0.1'
+}

--- a/test/integration/replica/bats/test_helpers.bash
+++ b/test/integration/replica/bats/test_helpers.bash
@@ -1,0 +1,18 @@
+http_get() {
+	if test -z "$HTTP_PROGRAM"
+	then
+		if which curl > /dev/null 2>&1
+		then
+			HTTP_PROGRAM="curl -s"
+		else
+			if which wget > /dev/null 2>&1
+			then
+				HTTP_PROGRAM="wget -O-"
+			else
+				echo "*** Please make sure either wget or curl exist"
+				exit 1
+			fi
+		fi
+	fi
+	$HTTP_PROGRAM $@
+}


### PR DESCRIPTION
This PR adds a new option to the `devpi_server` LWRP named `replicate`.  When it is set, the server is installed as a replica pointing to the value of the `replicate` option.  For example

``` ruby
devpi_server '/opt/devpi-slave' do
  replicate 'http://server-url:3141'
end
```
